### PR TITLE
added input for merge tags

### DIFF
--- a/machines/send-template-email.js
+++ b/machines/send-template-email.js
@@ -58,8 +58,7 @@ module.exports = {
     mergeVars: {
       friendlyName: "Merge Tags",
       description: "Content to be placed within template merge tags.",
-      typeclass: "array",
-      example: [{'name': 'FNAME', 'content': 'First Name'}, {'name': 'LNAME', 'content': 'Last Name'}],
+      example: [{'name': 'FNAME', 'content': 'First Name'}],
       addedManually: true
     }
   },

--- a/machines/send-template-email.js
+++ b/machines/send-template-email.js
@@ -54,6 +54,13 @@ module.exports = {
       friendlyName: 'From (name)',
       description: 'Full name of the sender.',
       example: 'Harold Greaseworthy'
+    },
+    mergeVars: {
+      friendlyName: "Merge Tags",
+      description: "Content to be placed within template merge tags.",
+      typeclass: "array",
+      example: [{'name': 'FNAME', 'content': 'First Name'}, {'name': 'LNAME', 'content': 'Last Name'}],
+      addedManually: true
     }
   },
 
@@ -90,6 +97,10 @@ module.exports = {
           subject: inputs.subject,
           from_email: inputs.fromEmail,
           from_name: inputs.fromName,
+          merge_vars: [{
+            rcpt: inputs.toEmail,
+            vars: inputs.mergeVars
+          }],
           auto_html: true
         }
       },


### PR DESCRIPTION
Was trying to use template_content for merge tags, but it only supported one. I added the merge_vars field to allow users to input multiple unique merge tags and content.
